### PR TITLE
Micro mummy turn mechanic

### DIFF
--- a/src/bgs_engine/bg_game/bobs_tavern_test.cpp
+++ b/src/bgs_engine/bg_game/bobs_tavern_test.cpp
@@ -79,6 +79,8 @@ TEST(BobsTavern, AllowsPlayerToBuyMinionByPosition) { // Probably useful for RL
 
 TEST(BobsTavern, ShowsPlayerHigherTierMinions) {
     auto player = std::make_unique<Player>("Test");
+    // Possible to randomly draw all from tier1 (although unlikely)
+    RngSingleton::getInstance(0, true);
     player->set_tavern_tier(3);
     player->refresh_tavern_minions();
     auto avail_minions = player->get_tavern_minions();

--- a/src/bgs_engine/bg_game/player.hpp
+++ b/src/bgs_engine/bg_game/player.hpp
@@ -154,10 +154,16 @@ public:
     }
 
     void start_turn() {
+	for (auto c : board->get_cards()) {
+	    c->start_turn_mechanic(this);
+	}
 	gold = max_gold;
     }
     
     void end_turn() {
+	for (auto c : board->get_cards()) {
+	    c->end_turn_mechanic(this);
+	}
 	turns_at_current_tier += 1;
 	if (max_gold < 10) max_gold++;
     }

--- a/src/bgs_engine/bg_game/player_test.cpp
+++ b/src/bgs_engine/bg_game/player_test.cpp
@@ -736,6 +736,43 @@ TEST(Player, MenagerieMugBattlecryMix) {
     EXPECT_EQ(total_hand_health + 9, total_board_health);
 }
 
+TEST(Player, MicroMummyStartTurnMechanic) {
+    auto f = BgCardFactory();
+    std::vector<std::shared_ptr<BgBaseCard> > hand_cards
+	{
+	 f.get_card("Micro Mummy"),
+	 f.get_card("Micro Mummy (Golden)")
+	};
+    auto in_hand = Hand(hand_cards);
+    auto player = Player(in_hand, "Test");
+    player.start_turn();
+    int total_hand_attack = 0;
+    int total_hand_health = 0;
+    for (auto card : in_hand.get_cards()) {
+	total_hand_attack += card->get_attack();
+	total_hand_health += card->get_health();
+    }
+    player.play_card(0, 0);
+    player.play_card(0, 1);
+
+    int total_board_attack = 0;
+    int total_board_health = 0;
+    for (auto card : player.get_board()->get_cards()) {
+	total_board_attack += card->get_attack();
+	total_board_health += card->get_health();
+    }
+    player.end_turn();
+
+    player.start_turn();
+    // Micro Mummies buff each other
+    auto micro_mummy = player.get_board()->get_cards()[0];
+    auto micro_mummy_golden = player.get_board()->get_cards()[1];
+    EXPECT_EQ(micro_mummy->get_attack(), 3); // Normally it's 1, but buffed +2
+    EXPECT_EQ(micro_mummy_golden->get_attack(), 3); // Normally it's 2, but buffed +1
+    EXPECT_TRUE(micro_mummy->has_reborn());
+    EXPECT_TRUE(micro_mummy_golden->has_reborn());
+}
+
 TEST(Player, MetaltoothLeaperBattlecry) {
     auto f = BgCardFactory();
     std::vector<std::shared_ptr<BgBaseCard> > hand_cards

--- a/src/bgs_engine/bg_game/player_test.cpp
+++ b/src/bgs_engine/bg_game/player_test.cpp
@@ -745,25 +745,13 @@ TEST(Player, MicroMummyStartTurnMechanic) {
 	};
     auto in_hand = Hand(hand_cards);
     auto player = Player(in_hand, "Test");
+
+    // Play out a quick turn
     player.start_turn();
-    int total_hand_attack = 0;
-    int total_hand_health = 0;
-    for (auto card : in_hand.get_cards()) {
-	total_hand_attack += card->get_attack();
-	total_hand_health += card->get_health();
-    }
     player.play_card(0, 0);
     player.play_card(0, 1);
-
-    int total_board_attack = 0;
-    int total_board_health = 0;
-    for (auto card : player.get_board()->get_cards()) {
-	total_board_attack += card->get_attack();
-	total_board_health += card->get_health();
-    }
     player.end_turn();
 
-    player.start_turn();
     // Micro Mummies buff each other
     auto micro_mummy = player.get_board()->get_cards()[0];
     auto micro_mummy_golden = player.get_board()->get_cards()[1];

--- a/src/bgs_engine/cards/bgs/BgBaseCard.hpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.hpp
@@ -131,6 +131,12 @@ public:
 
     // Triggered after a summon occurs, returns damage taken (wrathweave)
     virtual int mod_summoned(std::shared_ptr<BgBaseCard>, Board*, bool) { return 0; }
+
+    // Triggered at start of turn
+    virtual void start_turn_mechanic(Player*) {}
+
+    // Triggered at end of turn
+    virtual void end_turn_mechanic(Player*) {}
     
     virtual std::shared_ptr<BgBaseCard> get_copy() const;
 

--- a/src/bgs_engine/cards/bgs/BgCardFactory.cpp
+++ b/src/bgs_engine/cards/bgs/BgCardFactory.cpp
@@ -451,12 +451,12 @@ void BgCardFactory::init_cards() {
     std::shared_ptr<BgBaseCard> micro_machine_gold(new BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Machine (Golden)",
 								  "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION"));
     cards.emplace("Micro Machine (Golden)", micro_machine_gold);
-    std::shared_ptr<BgBaseCard> micro_mummy(new BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Mummy",
-							   "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION"));
+    auto micro_mummy = std::make_shared<MicroMummy>();
+    micro_mummy->set_reborn();
     cards.emplace("Micro Mummy", micro_mummy);
-    std::shared_ptr<BgBaseCard> micro_mummy_gold(new BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Mummy (Golden)",
-							   "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION"));
-    cards.emplace("Micro Mummy (Golden)", micro_mummy_gold);
+    auto micro_mummy_golden = std::make_shared<MicroMummyGolden>();
+    micro_mummy_golden->set_reborn();
+    cards.emplace("Micro Mummy (Golden)", micro_mummy_golden);
     std::shared_ptr<BgBaseCard> microbot(new BgBaseCard(1, "NEUTRAL", 1, 1, "Microbot",
 							"", "MECHANICAL", "", 1, "MINION"));
     cards.emplace("Microbot", microbot);

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -924,7 +924,7 @@ void MetaltoothLeaperGolden::do_battlecry(Player* p1) {
     // leaper.do_battlecry(p1);
 }
 
-void micro_mummy_start_turn(Player* p1, int attack_buff, BgBaseCard* this_) {
+void micro_mummy_end_turn(Player* p1, int attack_buff, BgBaseCard* this_) {
     if (p1->get_board()->get_cards().size() < 1) return;
     auto cards = p1->get_board()->get_cards();
     auto card_to_buff =  cards[RngSingleton::getInstance().get_rand_int() % cards.size()];
@@ -934,12 +934,12 @@ void micro_mummy_start_turn(Player* p1, int attack_buff, BgBaseCard* this_) {
     card_to_buff->set_attack(card_to_buff->get_attack() + attack_buff);
 }
 
-void MicroMummy::start_turn_mechanic(Player* p1) {
-    micro_mummy_start_turn(p1, 1, this);
+void MicroMummy::end_turn_mechanic(Player* p1) {
+    micro_mummy_end_turn(p1, 1, this);
 }
 
-void MicroMummyGolden::start_turn_mechanic(Player* p1) {
-    micro_mummy_start_turn(p1, 2, this);
+void MicroMummyGolden::end_turn_mechanic(Player* p1) {
+    micro_mummy_end_turn(p1, 2, this);
 }
 
 void MonstrousMacaw::do_preattack(std::shared_ptr<BgBaseCard> defender,

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -8,36 +8,6 @@
 #include "../../bg_game/battler.hpp"
 #include "../../bg_game/rng_singleton.hpp"
 
-// TODO: Add Player* to mod summoned interface?
-// void kalecgos_mods(Player* p1, BgBaseCard* tis) {
-//     if (!tis->has_battlecry()) return;
-//     int num_kalecgos = 0;
-//     for (auto c : p1->get_board()->get_cards()) {
-// 	if (c->get_name() == "Kalecgos, Arcane Aspect") num_kalecgos++;
-// 	if (c->get_name() == "Kalecgos, Arcane Aspect (Golden)") num_kalecgos += 2;
-//     }
-//     for (auto c : p1->get_board()->get_cards()) {
-// 	if (c->get_race() == "DRAGON") {
-// 	    c->set_attack(c->get_attack() + num_kalecgos);
-// 	    c->set_health(c->get_health() + num_kalecgos);
-// 	}
-//     }
-// }
-
-// void lt_garr_mods(Player* p1, BgBaseCard* tis) {
-//     if (!tis->get_race() != "ELEMENTAL") return;
-//     int num_elementals = 0;
-//     for (auto c : p1->get_board()->get_cards()) {
-// 	if (c->get_race() == "ELEMENTAL") num_elementals++;
-//     }
-//     for (auto c : p1->get_board()->get_cards()) {
-// 	if (c->get_race() == "DRAGON") {
-// 	    c->set_attack(c->get_attack() + num_kalecgos);
-// 	    c->set_health(c->get_health() + num_kalecgos);
-// 	}
-//     }
-// }
-
 // TODO: Efficiency
 void DeathrattleCard::deathrattle(Board* b1, Board* b2) {
     if (b1->contains("Baron Rivendare (Golden)")) {
@@ -954,6 +924,23 @@ void MetaltoothLeaperGolden::do_battlecry(Player* p1) {
     // leaper.do_battlecry(p1);
 }
 
+void micro_mummy_start_turn(Player* p1, int attack_buff, BgBaseCard* this_) {
+    if (p1->get_board()->get_cards().size() < 1) return;
+    auto cards = p1->get_board()->get_cards();
+    auto card_to_buff =  cards[RngSingleton::getInstance().get_rand_int() % cards.size()];
+    while (card_to_buff.get() == this_) {
+	card_to_buff =  cards[RngSingleton::getInstance().get_rand_int() % cards.size()];
+    }
+    card_to_buff->set_attack(card_to_buff->get_attack() + attack_buff);
+}
+
+void MicroMummy::start_turn_mechanic(Player* p1) {
+    micro_mummy_start_turn(p1, 1, this);
+}
+
+void MicroMummyGolden::start_turn_mechanic(Player* p1) {
+    micro_mummy_start_turn(p1, 2, this);
+}
 
 void MonstrousMacaw::do_preattack(std::shared_ptr<BgBaseCard> defender,
 				  Board* b1,

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -790,6 +790,22 @@ private:
     MetaltoothLeaper leaper;
 };
 
+class MicroMummy : public BgBaseCard {
+public:
+    MicroMummy() : BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Mummy",
+			      "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
+    virtual void start_turn_mechanic(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMummy>(*this); } // boilerplate that every drattle needs...
+};
+
+class MicroMummyGolden : public BgBaseCard {
+public:
+    MicroMummyGolden() : BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Mummy (Golden)",
+				    "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
+    virtual void start_turn_mechanic(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMummyGolden>(*this); } // boilerplate that every drattle needs...
+};
+
 class MonstrousMacaw : public BgBaseCard {
 public:
     MonstrousMacaw() : BgBaseCard(4, "NEUTRAL", 3, 3, "Monstrous Macaw",

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -794,7 +794,7 @@ class MicroMummy : public BgBaseCard {
 public:
     MicroMummy() : BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Mummy",
 			      "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
-    virtual void start_turn_mechanic(Player*) override;
+    virtual void end_turn_mechanic(Player*) override;
     virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMummy>(*this); } // boilerplate that every drattle needs...
 };
 
@@ -802,7 +802,7 @@ class MicroMummyGolden : public BgBaseCard {
 public:
     MicroMummyGolden() : BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Mummy (Golden)",
 				    "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
-    virtual void start_turn_mechanic(Player*) override;
+    virtual void end_turn_mechanic(Player*) override;
     virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMummyGolden>(*this); } // boilerplate that every drattle needs...
 };
 


### PR DESCRIPTION
CL:
1. Added `start_turn_mechanic` and `end_turn_mechanic` hooks to BgBaseCard. These are called on start/end of player turn.
2. Updated Micro Mummy to utilize these hooks
3. Removed some dead code