### PR TITLE
Turn mechanic cards

### DIFF
--- a/src/bgs_engine/bg_game/bobs_tavern.cpp
+++ b/src/bgs_engine/bg_game/bobs_tavern.cpp
@@ -19,7 +19,6 @@ std::vector<std::string> BobsTavern::refresh_minions(bool is_free) {
     if (!is_free) {
 	player->lose_gold(1);
     }
-    else { std::cerr << "Free refresh!" << std::endl; }
     _refresh_minions();
     return current_minions;
 }

--- a/src/bgs_engine/bg_game/bobs_tavern.cpp
+++ b/src/bgs_engine/bg_game/bobs_tavern.cpp
@@ -13,9 +13,13 @@ std::vector<std::string> BobsTavern::get_current_minions() {
     return current_minions;
 }
 
-std::vector<std::string> BobsTavern::refresh_minions() {
+std::vector<std::string> BobsTavern::refresh_minions(bool is_free) {
     if (player->get_gold() == 0) return current_minions;
-    player->lose_gold(1);
+    
+    if (!is_free) {
+	player->lose_gold(1);
+    }
+    else { std::cerr << "Free refresh!" << std::endl; }
     _refresh_minions();
     return current_minions;
 }

--- a/src/bgs_engine/bg_game/bobs_tavern.hpp
+++ b/src/bgs_engine/bg_game/bobs_tavern.hpp
@@ -13,7 +13,7 @@ class Player;
 class BobsTavern {
 public:
     BobsTavern(Player*);
-    std::vector<std::string> refresh_minions(); // Reduce players gold by one
+    std::vector<std::string> refresh_minions(bool is_free = false); // Reduce players gold by one
     std::vector<std::string> get_current_minions(); // Player arg not necessary for now, but probably will be in future
     void buy_minion(std::string minion); // Reduces players gold by three, adds minion to hand
     void buy_minion(int pos); // Reduces players gold by three, adds minion to hand

--- a/src/bgs_engine/bg_game/player.hpp
+++ b/src/bgs_engine/bg_game/player.hpp
@@ -71,7 +71,7 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const Player& p);
     int get_health() const { return health; }
     int get_max_health() const { return max_health; }
-    int get_damage_taken() const { std::cerr << "Dmg taken: " << max_health - health << std::endl; return max_health - health; }
+    int get_damage_taken() const { return max_health - health; }
     std::string get_name() const { return name; }
     int get_tavern_tier() const { return tavern_tier; }
     void set_tavern_tier(int tav_tier) { tavern_tier = tav_tier; }
@@ -135,7 +135,6 @@ public:
     std::vector<std::string> refresh_tavern_minions() {
 	if (num_free_refreshes > 0) {
 	    num_free_refreshes -= 1;
-	    std::cerr << "Free refresh!" << std::endl;
 	    return tavern->refresh_minions(true);
 	}
 	else {

--- a/src/bgs_engine/bg_game/player.hpp
+++ b/src/bgs_engine/bg_game/player.hpp
@@ -18,6 +18,7 @@ public:
 							      max_gold(3),
 							      max_health(40),
 							      name(name),
+							      num_free_refreshes(0),
 							      original_board(std::make_shared<Board>(board_)),
 							      tavern(std::make_shared<BobsTavern>(this)),
 							      tavern_tier(1),
@@ -29,6 +30,7 @@ public:
 			       max_gold(3),
 			       max_health(40),
 			       name(name),
+			       num_free_refreshes(0),
 			       original_board(new Board()),
 			       tavern(std::make_shared<BobsTavern>(this)),
 			       tavern_tier(1),
@@ -41,6 +43,7 @@ public:
 					  max_gold(3),
 					  max_health(40),
 					  name(name),
+					  num_free_refreshes(0),
 					  original_board(new Board()),
 					  tavern(std::make_shared<BobsTavern>(this)),
 					  tavern_tier(1),
@@ -73,6 +76,7 @@ public:
     int get_tavern_tier() const { return tavern_tier; }
     void set_tavern_tier(int tav_tier) { tavern_tier = tav_tier; }
     int get_turns_at_current_tier() const { return turns_at_current_tier; }
+    void set_free_refreshes(int num_free) { num_free_refreshes = num_free; }
 
     void add_card_to_hand(std::shared_ptr<BgBaseCard> card) {
 	hand.add_card(card);
@@ -129,7 +133,14 @@ public:
 
     // Tavern wrappers
     std::vector<std::string> refresh_tavern_minions() {
-	return tavern->refresh_minions();
+	if (num_free_refreshes > 0) {
+	    num_free_refreshes -= 1;
+	    std::cerr << "Free refresh!" << std::endl;
+	    return tavern->refresh_minions(true);
+	}
+	else {
+	    return tavern->refresh_minions();
+	}
     }
 
     std::vector<std::string> get_tavern_minions() {
@@ -175,6 +186,7 @@ private:
     int health;
     int max_health;
     std::string name;
+    int num_free_refreshes;
     std::shared_ptr<Board> original_board; // Read-only board
     int tavern_tier;
     std::shared_ptr<BobsTavern> tavern;

--- a/src/bgs_engine/bg_game/player_test.cpp
+++ b/src/bgs_engine/bg_game/player_test.cpp
@@ -736,7 +736,34 @@ TEST(Player, MenagerieMugBattlecryMix) {
     EXPECT_EQ(total_hand_health + 9, total_board_health);
 }
 
-TEST(Player, MicroMummyStartTurnMechanic) {
+TEST(Player, MicroMachineStartTurnMechanic) {
+    auto f = BgCardFactory();
+    std::vector<std::shared_ptr<BgBaseCard> > hand_cards
+	{
+	 f.get_card("Micro Machine"),
+	 f.get_card("Micro Machine (Golden)")
+	};
+    auto in_hand = Hand(hand_cards);
+    auto player = Player(in_hand, "Test");
+
+    // Play out a quick turn
+    player.start_turn();
+    player.play_card(0, 0);
+    player.play_card(0, 1);
+    player.end_turn();
+
+    // Start next turn
+    player.start_turn();
+
+    // Micro Mummies buff each other
+    auto micro_machine = player.get_board()->get_cards()[0];
+    auto micro_machine_golden = player.get_board()->get_cards()[1];
+    EXPECT_EQ(micro_machine->get_attack(), 2); // Normally it's 1, but buffed +1
+    EXPECT_EQ(micro_machine_golden->get_attack(), 4); // Normally it's 2, but buffed +2
+}
+
+
+TEST(Player, MicroMummyEndTurnMechanic) {
     auto f = BgCardFactory();
     std::vector<std::shared_ptr<BgBaseCard> > hand_cards
 	{

--- a/src/bgs_engine/bg_game/player_test.cpp
+++ b/src/bgs_engine/bg_game/player_test.cpp
@@ -923,6 +923,37 @@ TEST(Player, MurlocTidehunterBattlecry) {
 //     player.reroll_tav();
 // }
 
+TEST(Player, RefreshingAnomalyWorks) {
+    auto f = BgCardFactory();
+    std::vector<std::shared_ptr<BgBaseCard> > hand_cards
+	{
+	 f.get_card("Refreshing Anomaly"),
+	 f.get_card("Refreshing Anomaly (Golden)")
+	};
+    auto in_hand = Hand(hand_cards);
+    auto player = Player(in_hand, "Test");
+
+    // Play out a quick turn
+    player.start_turn();
+    // Non golden version allows one free refresh
+    player.play_card(0, 0);
+    EXPECT_EQ(player.get_gold(), 3);
+    player.refresh_tavern_minions();
+    EXPECT_EQ(player.get_gold(), 3);
+    player.refresh_tavern_minions();
+    EXPECT_EQ(player.get_gold(), 2);
+    // Gold version allows two free refreshes
+    player.play_card(0, 1);
+    EXPECT_EQ(player.get_gold(), 2);
+    player.refresh_tavern_minions();
+    EXPECT_EQ(player.get_gold(), 2);
+    player.refresh_tavern_minions();
+    EXPECT_EQ(player.get_gold(), 2);
+    player.refresh_tavern_minions();
+    EXPECT_EQ(player.get_gold(), 1);
+    player.end_turn();
+}
+
 
 TEST(Player, RockpoolHunterTargettedBattlecry) {
     auto f = BgCardFactory();

--- a/src/bgs_engine/cards/bgs/BgCardFactory.cpp
+++ b/src/bgs_engine/cards/bgs/BgCardFactory.cpp
@@ -445,12 +445,8 @@ void BgCardFactory::init_cards() {
     cards.emplace("Menagerie Mug (Golden)", std::make_shared<MenagerieMugGolden>());
     cards.emplace("Metaltooth Leaper", std::make_shared<MetaltoothLeaper>());
     cards.emplace("Metaltooth Leaper (Golden)", std::make_shared<MetaltoothLeaperGolden>());
-    std::shared_ptr<BgBaseCard> micro_machine(new BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Machine",
-							     "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION"));
-    cards.emplace("Micro Machine", micro_machine);
-    std::shared_ptr<BgBaseCard> micro_machine_gold(new BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Machine (Golden)",
-								  "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION"));
-    cards.emplace("Micro Machine (Golden)", micro_machine_gold);
+    cards.emplace("Micro Machine", std::make_shared<MicroMachine>());
+    cards.emplace("Micro Machine (Golden)", std::make_shared<MicroMachineGolden>());
     auto micro_mummy = std::make_shared<MicroMummy>();
     micro_mummy->set_reborn();
     cards.emplace("Micro Mummy", micro_mummy);

--- a/src/bgs_engine/cards/bgs/BgCardFactory.cpp
+++ b/src/bgs_engine/cards/bgs/BgCardFactory.cpp
@@ -547,10 +547,8 @@ void BgCardFactory::init_cards() {
     cards.emplace("Red Whelp (Golden)", std::make_shared<RedWhelpGolden>());
     // cards.emplace("Redemption", BgBaseCard(-1, "PALADIN", 1, -1, "Redemption",
     // 					   "['SECRET']", "", "COMMON", -1, "SPELL"));
-    cards.emplace("Refreshing Anomaly", std::make_shared<BgBaseCard>(1, "NEUTRAL", -1, 3, "Refreshing Anomaly",
-								     "", "ELEMENTAL", "", 1, "MINION"));
-    cards.emplace("Refreshing Anomaly (Golden)", std::make_shared<BgBaseCard>(2, "NEUTRAL", -1, 6, "Refreshing Anomaly (Golden)",
-									      "", "ELEMENTAL", "", 1, "MINION"));
+    cards.emplace("Refreshing Anomaly", std::make_shared<RefreshingAnomaly>());
+    cards.emplace("Refreshing Anomaly (Golden)", std::make_shared<RefreshingAnomalyGolden>());
     cards.emplace("Replicating Menace", std::make_shared<ReplicatingMenace>());
     cards.emplace("Replicating Menace (Golden)", std::make_shared<ReplicatingMenaceGolden>());
     // std::shared_ptr<BgBaseCard> ripsnarl(new PirateCard(3, "NEUTRAL", 4, 4, "Ripsnarl Captain",

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -924,6 +924,18 @@ void MetaltoothLeaperGolden::do_battlecry(Player* p1) {
     // leaper.do_battlecry(p1);
 }
 
+void micro_machine_start_turn(Player*, int attack_buff, BgBaseCard* this_) {
+    this_->set_attack(this_->get_attack() + attack_buff);
+}
+
+void MicroMachine::start_turn_mechanic(Player* p1) {
+    micro_machine_start_turn(p1, 1, this);
+}
+
+void MicroMachineGolden::start_turn_mechanic(Player* p1) {
+    micro_machine_start_turn(p1, 2, this);
+}
+
 void micro_mummy_end_turn(Player* p1, int attack_buff, BgBaseCard* this_) {
     if (p1->get_board()->get_cards().size() < 1) return;
     auto cards = p1->get_board()->get_cards();

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -1176,6 +1176,15 @@ void RedWhelpGolden::do_precombat(Board* b1, Board* b2) {
     }
 }
 
+void RefreshingAnomaly::do_battlecry(Player* p1) {
+    std::cerr << "Setting free..." << std::endl;
+    p1->set_free_refreshes(1);
+}
+
+void RefreshingAnomalyGolden::do_battlecry(Player* p1) {
+    p1->set_free_refreshes(2);
+}
+
 void ReplicatingMenace::do_deathrattle(Board* b1, Board* b2) {
     multi_summon(3, b1);
 }

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -1177,7 +1177,6 @@ void RedWhelpGolden::do_precombat(Board* b1, Board* b2) {
 }
 
 void RefreshingAnomaly::do_battlecry(Player* p1) {
-    std::cerr << "Setting free..." << std::endl;
     p1->set_free_refreshes(1);
 }
 

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -790,6 +790,22 @@ private:
     MetaltoothLeaper leaper;
 };
 
+class MicroMachine : public BgBaseCard {
+public:
+    MicroMachine() : BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Machine",
+				"['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
+    virtual void start_turn_mechanic(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMachine>(*this); } // boilerplate that every drattle needs...
+};
+
+class MicroMachineGolden : public BgBaseCard {
+public:
+    MicroMachineGolden() : BgBaseCard(2, "NEUTRAL", 2, 4, "Micro Machine (Golden)",
+				      "['TRIGGER_VISUAL']", "MECHANICAL", "COMMON", 1, "MINION") {}
+    virtual void start_turn_mechanic(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<MicroMachineGolden>(*this); } // boilerplate that every drattle needs...
+};
+
 class MicroMummy : public BgBaseCard {
 public:
     MicroMummy() : BgBaseCard(1, "NEUTRAL", 2, 2, "Micro Mummy",

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -1035,6 +1035,22 @@ private:
     RedWhelp rw;
 };
 
+class RefreshingAnomaly : public BattlecryCard {
+public:
+    RefreshingAnomaly() : BgBaseCard(1, "NEUTRAL", -1, 3, "Refreshing Anomaly",
+				     "", "ELEMENTAL", "", 1, "MINION") {}
+    virtual void do_battlecry(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<RefreshingAnomaly>(*this); } // boilerplate that every drattle needs...
+};
+
+class RefreshingAnomalyGolden : public BattlecryCard {
+public:
+    RefreshingAnomalyGolden() : BgBaseCard(2, "NEUTRAL", -1, 6, "Refreshing Anomaly (Golden)",
+					   "", "ELEMENTAL", "", 1, "MINION") {}
+    virtual void do_battlecry(Player*) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<RefreshingAnomalyGolden>(*this); } // boilerplate that every drattle needs...
+};
+
 class ReplicatingMenace : public DeathrattleCard {
 public:
     ReplicatingMenace() : BgBaseCard(3, "NEUTRAL", 4, 1, "Replicating Menace",


### PR DESCRIPTION
This finishes all the tier1 cards and their mechanics. Woo! I plan to keep iterating on this branch.

CL:

1. Added Micro Machine start turn mechanic (https://hearthstone.gamepedia.com/Micro_Machine_(Battlegrounds))
2. Added Refreshing Anomoly battlecry (not a start-turn mechanic, but turn-dependent: https://hearthstone.gamepedia.com/Refreshing_Anomaly)