### PR TITLE
Drattle semi fc

### DIFF
--- a/src/bgs_engine/bg_game/battler_test.cpp
+++ b/src/bgs_engine/bg_game/battler_test.cpp
@@ -214,6 +214,30 @@ TEST(Battler, AmalgadonForcedLivingSporeAdapt) {
     EXPECT_EQ(res.who_won, "draw");
 }
 
+TEST(Battler, AmalgadonForcedLivingSporeAdaptWithBaron) {
+    auto f = BgCardFactory();
+    auto amalgadon = f.get_card("Amalgadon");
+    amalgadon->adapt("Living Spores");
+    std::vector<std::shared_ptr<BgBaseCard> > p1_cards
+	{
+	 amalgadon,
+	 f.get_card("Baron Rivendare")
+	};
+    auto th = f.get_card("Murloc Tidehunter");
+    th->set_attack(7);
+    th->set_health(6 + 4 + 1); // 6 amal, 4 spores, 1 from baron
+    std::vector<std::shared_ptr<BgBaseCard> > p2_cards
+	{
+	 th
+	};
+    std::shared_ptr<Board> board1(new Board(p1_cards));
+    std::shared_ptr<Board> board2(new Board(p2_cards));
+    std::unique_ptr<Player> p1(new Player(board1, "Tess"));
+    std::unique_ptr<Player> p2(new Player(board2, "Edwin"));
+    auto battler = Battler(p1.get(), p2.get());
+    auto res = battler.sim_battle();
+    EXPECT_EQ(res.who_won, "draw");
+}
 
 TEST(Battler, Baron) {
     auto f = BgCardFactory();

--- a/src/bgs_engine/bg_game/battler_test.cpp
+++ b/src/bgs_engine/bg_game/battler_test.cpp
@@ -189,6 +189,32 @@ TEST(Battler, CanHandleBasicDeathrattles) {
     EXPECT_EQ(res.damage_taken, 0); 
 }
 
+TEST(Battler, AmalgadonForcedLivingSporeAdapt) {
+    auto f = BgCardFactory();
+    auto amalgadon = f.get_card("Amalgadon");
+    amalgadon->adapt("Living Spores");
+    std::vector<std::shared_ptr<BgBaseCard> > p1_cards
+	{
+	 amalgadon
+	};
+    auto th = f.get_card("Murloc Tidehunter");
+    th->set_attack(6);
+    th->set_health(8);
+    std::vector<std::shared_ptr<BgBaseCard> > p2_cards
+	{
+	 th
+	};
+    std::shared_ptr<Board> board1(new Board(p1_cards));
+    std::shared_ptr<Board> board2(new Board(p2_cards));
+    std::unique_ptr<Player> p1(new Player(board1, "Tess"));
+    std::unique_ptr<Player> p2(new Player(board2, "Edwin"));
+    auto battler = Battler(p1.get(), p2.get());
+    auto res = battler.sim_battle();
+    // amagadon deals 6, each spore deals 2, draw
+    EXPECT_EQ(res.who_won, "draw");
+}
+
+
 TEST(Battler, Baron) {
     auto f = BgCardFactory();
     std::vector<std::shared_ptr<BgBaseCard> > p1_cards

--- a/src/bgs_engine/bg_game/battler_test.cpp
+++ b/src/bgs_engine/bg_game/battler_test.cpp
@@ -652,6 +652,33 @@ TEST(Battler, IronhideDirehorn) {
     EXPECT_EQ(res.who_won, "Tess");
 }
 
+TEST(Battler, InfestedWolfWithBaronForcedLivingSporeAdapt) {
+    // TODO: Small bug here where summons aren't ordered properly.
+    // Should be the 1/1 wolf tokens and then the two spores
+    auto f = BgCardFactory();
+    auto woof = f.get_card("Infested Wolf");    
+    woof->adapt("Living Spores");
+    std::vector<std::shared_ptr<BgBaseCard> > p1_cards
+	{
+	 woof,
+	 f.get_card("Baron Rivendare")
+	};
+    auto th = f.get_card("Murloc Tidehunter");
+    th->set_attack(7);
+    th->set_health(3 + 1 + 6); // 3 from wolf, 1 from baron, 6 from summoned tokens
+    std::vector<std::shared_ptr<BgBaseCard> > p2_cards
+	{
+	 th
+	};
+    std::shared_ptr<Board> board1(new Board(p1_cards));
+    std::shared_ptr<Board> board2(new Board(p2_cards));
+    std::unique_ptr<Player> p1(new Player(board1, "Tess"));
+    std::unique_ptr<Player> p2(new Player(board2, "Edwin"));
+    auto battler = Battler(p1.get(), p2.get());
+    auto res = battler.sim_battle();
+    // wolf deals 3, baron deals 1, 6 tokens deal 6, has 3 + 1 + 6 hp, draw
+    EXPECT_EQ(res.who_won, "draw");
+}
 
 // So similar to ratpack we skip it for now...
 // TEST(Battler, InfestedWolfDrattle) {

--- a/src/bgs_engine/cards/bgs/BgBaseCard.cpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.cpp
@@ -66,6 +66,36 @@ void BgBaseCard::adapt(std::string _test_adapt) {
     adapt_count++;
 }
 
+void BgBaseCard::deathrattle(Board* b1, Board* b2) {
+    if (b1->contains("Baron Rivendare (Golden)")) {
+	do_deathrattle(b1, b2);
+	do_deathrattle(b1, b2);
+	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	}
+    }
+    else if (b1->contains("Baron Rivendare")) {
+	do_deathrattle(b1, b2);
+	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	}
+    }
+    else {
+	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
+	    c->do_deathrattle(b1, b2);
+	}
+    }
+}
+
 void BgBaseCard::take_damage(int damage, std::string who_from_race, Board* b1, Board* b2) {
     if (divine_shield) {
 	divine_shield = false;

--- a/src/bgs_engine/cards/bgs/BgBaseCard.cpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.cpp
@@ -18,6 +18,54 @@ std::ostream& operator<<(std::ostream& os, const BgBaseCard& card) {
     return os;
 }
 
+void BgBaseCard::adapt(std::string _test_adapt) {
+    std::string adaptation;
+    if (_test_adapt == "None") {
+	std::vector<std::string> adapts = {"Crackling Shield",
+					   "Flaming Claws",
+					   "Living Spores",
+					   "Lightning Speed",
+					   "Massive",
+					   "Volcanic Might",
+					   "Rocky Carapace",
+					   "Poison Spit"};
+	adaptation = adapts[RngSingleton::getInstance().get_rand_int() % adapts.size()];
+    }
+    else {
+	adaptation = _test_adapt;
+    }
+    if (adaptation == "Crackling Shield") {
+	set_divine_shield();
+    }
+    else if (adaptation == "Flaming Claws") {
+	set_attack(get_attack() + 3);
+    }
+    else if (adaptation == "Living Spores") {
+	auto c = BgCardFactory().get_card("Living Spore Drattle");
+	deathrattle_cards.push_back(c);
+    }
+    else if (adaptation == "Lightning Speed") {
+	set_windfury();
+    }
+    else if (adaptation == "Massive") {
+	set_taunt();
+    }
+    else if (adaptation == "Volcanic Might") {
+	set_attack(get_attack() + 1);
+	set_health(get_health() + 1);
+    }
+    else if (adaptation == "Rocky Carapace") {
+	set_health(get_health() + 3);
+    }
+    else if (adaptation == "Poison Spit") {
+	set_poison();
+    }
+    else {
+	throw std::runtime_error("Unknown adapt");
+    }
+    adapt_count++;
+}
+
 void BgBaseCard::take_damage(int damage, std::string who_from_race, Board* b1, Board* b2) {
     if (divine_shield) {
 	divine_shield = false;

--- a/src/bgs_engine/cards/bgs/BgBaseCard.hpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.hpp
@@ -66,40 +66,7 @@ public:
     // (ex: stat-buffs that die)
     // Note: Actual deathrattle cards handled by DeathrattleCard class
     virtual void do_deathrattle(Board* b1, Board* b2) { }
-    
-    virtual void deathrattle(Board* b1, Board* b2) {
-	// if (b1->contains("Baron Rivendare (Golden)")) {
-	//     do_deathrattle(b1, b2);
-	//     do_deathrattle(b1, b2);
-	//     do_deathrattle(b1, b2);
-	//     for (auto c : deathrattle_cards) {
-	// 	c->set_death_pos(this->death_pos);
-	// 	c->do_deathrattle(b1, b2);
-	// 	c->do_deathrattle(b1, b2);
-	// 	c->do_deathrattle(b1, b2);
-	//     }
-	// }
-	// else if (b1->contains("Baron Rivendare")) {
-	//     do_deathrattle(b1, b2);
-	//     do_deathrattle(b1, b2);
-	//     for (auto c : deathrattle_cards) {
-	// 	c->set_death_pos(this->death_pos);
-	// 	c->do_deathrattle(b1, b2);
-	// 	c->do_deathrattle(b1, b2);
-	//     }
-	// }
-	// else {
-	//     do_deathrattle(b1, b2);
-	//     for (auto c : deathrattle_cards) {
-	// 	c->set_death_pos(this->death_pos);
-	// 	c->do_deathrattle(b1, b2);
-	//     }
-	// }
-	do_deathrattle(b1, b2);
-	for (auto c : deathrattle_cards) {
-	    c->do_deathrattle(b1, b2);
-	}
-    }
+    virtual void deathrattle(Board* b1, Board* b2);
     
     // Triggered before every attack (ex: glyph gaurdian mechanic)
     virtual void do_preattack(std::shared_ptr<BgBaseCard>,

--- a/src/bgs_engine/cards/bgs/BgBaseCard.hpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.hpp
@@ -68,6 +68,33 @@ public:
     virtual void do_deathrattle(Board* b1, Board* b2) { }
     
     virtual void deathrattle(Board* b1, Board* b2) {
+	// if (b1->contains("Baron Rivendare (Golden)")) {
+	//     do_deathrattle(b1, b2);
+	//     do_deathrattle(b1, b2);
+	//     do_deathrattle(b1, b2);
+	//     for (auto c : deathrattle_cards) {
+	// 	c->set_death_pos(this->death_pos);
+	// 	c->do_deathrattle(b1, b2);
+	// 	c->do_deathrattle(b1, b2);
+	// 	c->do_deathrattle(b1, b2);
+	//     }
+	// }
+	// else if (b1->contains("Baron Rivendare")) {
+	//     do_deathrattle(b1, b2);
+	//     do_deathrattle(b1, b2);
+	//     for (auto c : deathrattle_cards) {
+	// 	c->set_death_pos(this->death_pos);
+	// 	c->do_deathrattle(b1, b2);
+	// 	c->do_deathrattle(b1, b2);
+	//     }
+	// }
+	// else {
+	//     do_deathrattle(b1, b2);
+	//     for (auto c : deathrattle_cards) {
+	// 	c->set_death_pos(this->death_pos);
+	// 	c->do_deathrattle(b1, b2);
+	//     }
+	// }
 	do_deathrattle(b1, b2);
 	for (auto c : deathrattle_cards) {
 	    c->do_deathrattle(b1, b2);

--- a/src/bgs_engine/cards/bgs/BgBaseCard.hpp
+++ b/src/bgs_engine/cards/bgs/BgBaseCard.hpp
@@ -56,50 +56,7 @@ public:
 					  type(other.type),
 					  adapt_count(0) {}
 
-    void adapt() {
-	std::cerr << "WARNING! Adapt only partially working." << std::endl;
-	std::vector<std::string> adapts = {"Crackling Shield",
-					   "Flaming Claws",
-					   // "Living Spores",
-					   "Lightning Speed",
-					   "Massive",
-					   "Volcanic Might",
-					   "Rocky Carapace",
-					   "Poison Spit"};
-	auto adaptation = adapts[RngSingleton::getInstance().get_rand_int() % adapts.size()];
-	if (adaptation == "Crackling Shield") {
-	    set_divine_shield();
-	}
-	else if (adaptation == "Flaming Claws") {
-	    set_attack(get_attack() + 3);
-	}
-	// else if (adaptation == "Living Spores") {
-	//     TODO: Set deathrattle...
-	//     set_deathrattle(lambda b1, b2: ...);
-	// }
-	else if (adaptation == "Lightning Speed") {
-	    set_windfury();
-	}
-	else if (adaptation == "Massive") {
-	    set_taunt();
-	}
-	else if (adaptation == "Volcanic Might") {
-	    set_attack(get_attack() + 1);
-	    set_health(get_health() + 1);
-	}
-	else if (adaptation == "Rocky Carapace") {
-	    set_health(get_health() + 3);
-	}
-	else if (adaptation == "Poison Spit") {
-	    set_poison();
-	}
-	else {
-	    throw std::runtime_error("Unknown adapt");
-	}
-	std::cerr << "Adapt count: " << adapt_count << std::endl;
-	adapt_count++;
-	std::cerr << "Adapt count (after): " << adapt_count << std::endl;
-    }
+    void adapt(std::string _test_adapt="None");
 
     virtual void do_battlecry(Player*) {}
     virtual void battlecry(Player*) {}
@@ -108,8 +65,14 @@ public:
     // Triggered on death
     // (ex: stat-buffs that die)
     // Note: Actual deathrattle cards handled by DeathrattleCard class
-    virtual void do_deathrattle(Board*, Board*) {}
-    virtual void deathrattle(Board* b1, Board* b2) { do_deathrattle(b1, b2); }
+    virtual void do_deathrattle(Board* b1, Board* b2) { }
+    
+    virtual void deathrattle(Board* b1, Board* b2) {
+	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->do_deathrattle(b1, b2);
+	}
+    }
     
     // Triggered before every attack (ex: glyph gaurdian mechanic)
     virtual void do_preattack(std::shared_ptr<BgBaseCard>,
@@ -208,6 +171,7 @@ public:
     virtual ~BgBaseCard() {}
     
 protected:
+    std::vector<std::shared_ptr<BgBaseCard>> deathrattle_cards; // Used for magnetic effects or other deathrattle stacking
     int attack;
     std::string card_class;
     int cost;

--- a/src/bgs_engine/cards/bgs/BgCardFactory.cpp
+++ b/src/bgs_engine/cards/bgs/BgCardFactory.cpp
@@ -397,6 +397,12 @@ void BgCardFactory::init_cards() {
     cards.emplace("Lightfang Enforcer (Golden)", std::make_shared<LightfangEnforcerGolden>());
     cards.emplace("Lil' Rag", std::make_shared<LilRag>());
     cards.emplace("Lil' Rag (Golden)", std::make_shared<LilRagGolden>());
+    std::shared_ptr<BgBaseCard> living_spore(new BgBaseCard(1, "NEUTRAL", 1, 1,  "Living Spore",
+							    "", "", "COMMON", 1, "MINION"));
+    cards.emplace("Living Spore", living_spore);
+    // NOTE: Not a real card, useful for adapt/magnetic mechanic
+    cards.emplace("Living Spore Drattle", std::make_shared<LivingSporeDrattle>());
+    
 
 
     // M

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -54,6 +54,7 @@ void DeathrattleCard::deathrattle(Board* b1, Board* b2) {
 	do_deathrattle(b1, b2);
 	do_deathrattle(b1, b2);
 	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
 	    c->do_deathrattle(b1, b2);
 	    c->do_deathrattle(b1, b2);
 	    c->do_deathrattle(b1, b2);
@@ -63,6 +64,7 @@ void DeathrattleCard::deathrattle(Board* b1, Board* b2) {
 	do_deathrattle(b1, b2);
 	do_deathrattle(b1, b2);
 	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
 	    c->do_deathrattle(b1, b2);
 	    c->do_deathrattle(b1, b2);
 	}
@@ -70,6 +72,7 @@ void DeathrattleCard::deathrattle(Board* b1, Board* b2) {
     else {
 	do_deathrattle(b1, b2);
 	for (auto c : deathrattle_cards) {
+	    c->set_death_pos(this->death_pos);
 	    c->do_deathrattle(b1, b2);
 	}
     }

--- a/src/bgs_engine/cards/bgs/BgCards.cpp
+++ b/src/bgs_engine/cards/bgs/BgCards.cpp
@@ -53,13 +53,25 @@ void DeathrattleCard::deathrattle(Board* b1, Board* b2) {
 	do_deathrattle(b1, b2);
 	do_deathrattle(b1, b2);
 	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	}
     }
     else if (b1->contains("Baron Rivendare")) {
 	do_deathrattle(b1, b2);
 	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->do_deathrattle(b1, b2);
+	    c->do_deathrattle(b1, b2);
+	}
     }
     else {
 	do_deathrattle(b1, b2);
+	for (auto c : deathrattle_cards) {
+	    c->do_deathrattle(b1, b2);
+	}
     }
 }
 
@@ -868,6 +880,15 @@ int LilRagGolden::mod_summoned(std::shared_ptr<BgBaseCard> card, Board* b1, bool
     lr.mod_summoned(card, b1, from_hand);
     lr.mod_summoned(card, b1, from_hand);
     return 0;
+}
+
+void LivingSporeDrattle::do_deathrattle(Board* b1, Board* b2) {
+    multi_summon(2, b1);
+}
+
+std::shared_ptr<BgBaseCard> LivingSporeDrattle::summon() {
+    auto f = BgCardFactory();
+    return f.get_card("Living Spore");
 }
 
 void MajordomoExecutus::end_turn_mechanic(Player* p1) {

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -726,6 +726,16 @@ private:
     LilRag lr;
 };
 
+// Fake card, but can be added to adapt deathrattle_card list, similar to magnetic mechanic
+class LivingSporeDrattle : public DeathrattleCard {
+public:
+    LivingSporeDrattle() : BgBaseCard(0, "N/A", 0, 0, "Living Spore Drattle",
+				      "['DEATHRATTLE']", "", "COMMON", 0, "MINION") {}
+    virtual void do_deathrattle(Board* b1, Board* b2) override;
+    virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<LivingSporeDrattle>(*this); } // boilerplate that every drattle needs...
+    std::shared_ptr<BgBaseCard> summon() override;
+};
+
 class MajordomoExecutus : public BgBaseCard {
 public:
     MajordomoExecutus() : BgBaseCard(6, "NEUTRAL", 6, 3, "Majordomo Executus",

--- a/src/bgs_engine/cards/bgs/BgCards.hpp
+++ b/src/bgs_engine/cards/bgs/BgCards.hpp
@@ -497,7 +497,7 @@ public:
 
 class InfestedWolf : public DeathrattleCard {
 public:
-    InfestedWolf() : BgBaseCard(6, "HUNTER", 4, 6, "Infested Wolf",
+    InfestedWolf() : BgBaseCard(3, "HUNTER", 4, 3, "Infested Wolf",
 				"['DEATHRATTLE']", "BEAST", "RARE", 3, "MINION") {}
     virtual void do_deathrattle(Board* b1, Board* b2) override;
     virtual std::shared_ptr<BgBaseCard> get_copy() const override { return std::make_shared<InfestedWolf>(*this); } // boilerplate that every drattle needs...


### PR DESCRIPTION
I thought in order to do adapting w/ living spores and magnetic mechanics we'd need first class deathrattle functions, but came up w/ an alternative. The lack of dynamism w/ `std::bind` was what caused me to backpedal a bit. Anyway, new strategy is to keep a stack of `deathrattle_cards` on each card s.t. when the card dies, the deathrattles on these cards go off (in order).